### PR TITLE
Typo fix at Observable example

### DIFF
--- a/complete-tutorial.org
+++ b/complete-tutorial.org
@@ -342,7 +342,7 @@ Let's not talk too much so instead let's play with Observables to get a feel. Op
 
   Observables play well with promises, and allow composition with other Observables and promises. For an example, let's make multiple ajax requests, and log their status to console.
 #+begin_src javascript
-  import {get} from 'jQuery';
+  import {ajax} from 'jQuery';
 
   let urls = [
     'http://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=test'


### PR DESCRIPTION
Code is using `ajax`, instead of `get`.

``` javascript
let fetchFeed = (url) => {
  return ajax({
    url: `http://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=30&q=${url}`,
    dataType: 'jsonp'
  }).promise();
};
```
